### PR TITLE
PORTAL-394

### DIFF
--- a/backend-dockerfile
+++ b/backend-dockerfile
@@ -1,0 +1,6 @@
+FROM cbiitssrepo/bento-backend:release
+MAINTAINER icdc devops team
+
+RUN rm -rf /usr/local/tomcat/webapps/ROOT
+COPY target/ROOT.war /usr/local/tomcat/webapps/
+


### PR DESCRIPTION
This moves the dockerfile 'backend-dockerfile' to the repositories root directory. This is required for deploying the updated backend.