### PR TITLE
2.6.0 vulnerable fix (#98)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN mvn package -DskipTests
 
 # Production stage
-FROM tomcat:11.0.4-jdk17 AS fnl_base_image
+FROM tomcat:11.0.5-jdk17 AS fnl_base_image
 
 RUN apt-get update && apt-get -y upgrade
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,14 +17,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.13</version>
+        <version>3.2.11</version>
     </parent>
 
 
     <properties>
         <java.version>17</java.version>
-        <spring.version>6.0.14</spring.version>
-        <spring.restdocs.version>3.0.1</spring.restdocs.version>
+        <spring.version>6.1.14</spring.version>
+        <spring.restdocs.version>3.0.2</spring.restdocs.version>
         <snakeyaml.version>2.3</snakeyaml.version>
         <kotlin.version>1.8.0</kotlin.version>
     </properties>
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>${spring.version}</version>
+            <version>6.1.14</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>6.0.17</version>
+            <version>6.1.14</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.restdocs</groupId>
@@ -181,7 +181,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>10.1.34</version>
+            <version>10.1.39</version>
         </dependency>
         <!-- JUnit -->
         <dependency>
@@ -227,9 +227,20 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>4.1.119.Final</version>
+        </dependency>
+        <dependency>
             <groupId>org.neo4j.driver</groupId>
             <artifactId>neo4j-java-driver</artifactId>
-            <version>5.27.0</version>
+            <version>5.28.2</version>
+            <exclusions>
+				<exclusion>
+					<groupId>io.netty</groupId>
+					<artifactId>netty-handler</artifactId>
+				</exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
@@ -268,7 +279,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.14</version>
+			<version>4.5.13</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>


### PR DESCRIPTION
* Update pom.xml to fix vulnerabilities

* Update to resolve netty-handler vulnerability

* Update Dockerfile to use 10.1.39 tomcat with jdk17

* Update dockerfile

* Update bento core